### PR TITLE
Fix safari ios scrolling bug in the dialogs

### DIFF
--- a/src/components/Dialog/Dialog/MobileDialog.tsx
+++ b/src/components/Dialog/Dialog/MobileDialog.tsx
@@ -90,16 +90,18 @@ export const MobileDialog = ({
 }
 
 const StyledDivForModal = styled('div', {
+  opacity: 0,
   backgroundColor: '$backgroundColors$base',
-  zIndex: '$2',
-  width: '100%',
-  height: '100%',
-  minHeight: '100vh',
   position: 'fixed',
-  overflowY: 'auto',
+  zIndex: '$2',
   left: 0,
   top: 0,
-  opacity: 0
+  width: '100%',
+  height: '100vh',
+  overflow: 'scroll',
+  '-webkit-overflow-scrolling': 'touch'
 })
 
-const StyledDivForScrollArea = styled('div', {})
+const StyledDivForScrollArea = styled('div', {
+  minHeight: '100vh'
+})

--- a/src/components/Dialog/Dialog/MobileDialog.tsx
+++ b/src/components/Dialog/Dialog/MobileDialog.tsx
@@ -90,18 +90,16 @@ export const MobileDialog = ({
 }
 
 const StyledDivForModal = styled('div', {
-  opacity: 0,
   backgroundColor: '$backgroundColors$base',
-  position: 'fixed',
   zIndex: '$2',
+  width: '100%',
+  height: '100%',
+  minHeight: '100vh',
+  position: 'fixed',
+  overflowY: 'auto',
   left: 0,
   top: 0,
-  width: '100%',
-  height: '100vh',
-  overflow: 'scroll',
-  '-webkit-overflow-scrolling': 'touch'
+  opacity: 0
 })
 
-const StyledDivForScrollArea = styled('div', {
-  minHeight: '100vh'
-})
+const StyledDivForScrollArea = styled('div', {})


### PR DESCRIPTION
This should fix the iOS scrolling bug in safari when the dialog content is bigger than the screen height. 